### PR TITLE
perf: decrease FCP

### DIFF
--- a/layout/_partials/footer.pug
+++ b/layout/_partials/footer.pug
@@ -34,7 +34,7 @@ div(class="status")
             if beianN && RC
                 br
                 a(target="_blank" href=`https://www.beian.gov.cn/portal/registerSystemInfo?recordcode=${RC}`)
-                    img(src=theme.statics + theme.assets + '/' + theme.footer.icp.icon style="max-width: 2em;display:inline;")
+                    img(src=theme.statics + theme.assets + '/' + theme.footer.icp.icon style="max-width: 2em;display:inline;" width="20" height="20")
                     != beianN
     != shokax_inject('status')
 

--- a/scripts/helpers/asset.ts
+++ b/scripts/helpers/asset.ts
@@ -93,7 +93,7 @@ hexo.extend.helper.register('_vendor_font', () => {
   const fontDisplay = '&display=swap'
   const fontSubset = '&subset=latin,latin-ext'
   const fontStyles = ':300,300italic,400,400italic,700,700italic'
-  const fontHost = '//fonts.geekzu.org'
+  const fontHost = 'https://fonts.googleapis.com'
 
   // Get a font list from config
   let fontFamilies = ['global', 'logo', 'title', 'headings', 'posts', 'codes'].map(item => {

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -148,6 +148,7 @@ input, textarea {
 }
 @font-face {
   font-family: 'ic';
+  font-display: swap;
   src: url('//at.alicdn.com/t/font_' + $iconfont + '.eot');
   src: url('//at.alicdn.com/t/font_' + $iconfont + '.eot?#iefix') format('embedded-opentype'),
   url('//at.alicdn.com/t/font_' + $iconfont + '.woff2') format('woff2'),
@@ -157,9 +158,9 @@ input, textarea {
 }
 
 @font-face {
-    font-family: 'jetbrains-mono';
-    font-display: swap;
-    src: url("https://cdn.jsdelivr.net/gh/JetBrains/JetBrainsMono@2.242/fonts/webfonts/JetBrainsMono-Regular.woff2") format("woff2");
+  font-family: 'jetbrains-mono';
+  font-display: swap;
+  src: url("https://cdn.jsdelivr.net/gh/JetBrains/JetBrainsMono@2.242/fonts/webfonts/JetBrainsMono-Regular.woff2") format("woff2");
 }
 
 .ic {


### PR DESCRIPTION
before:
![image](https://github.com/theme-shoka-x/hexo-theme-shokaX/assets/49871906/71d585f4-efc5-4e40-bc42-2680779f1441)
after:
![image](https://github.com/theme-shoka-x/hexo-theme-shokaX/assets/49871906/fed90b32-3824-4029-9b81-58ed8f55fc0c)
令人感到困惑的是本应用来加速字体的CDN结果反而重定向到了原来的谷歌API（有时甚至需要重定向两次）：
![image](https://github.com/theme-shoka-x/hexo-theme-shokaX/assets/49871906/41dd346c-9066-4c9a-bede-93cc43b17132)
![image](https://github.com/theme-shoka-x/hexo-theme-shokaX/assets/49871906/f1cb4a25-c1ac-4e57-b6a3-b6e74a2cb3ff)