### PR TITLE
fix: 修复 zh-HK 翻译

### DIFF
--- a/languages/zh-HK.yml
+++ b/languages/zh-HK.yml
@@ -133,7 +133,7 @@ symbols_count_time:
   count_total: 站點總字數
   time: 閱讀時長
   time_total: 站點閱讀時長
-  time_minutes: 分鍾
+  time_minutes: 分鐘
   word: 字
   view: 次
 


### PR DESCRIPTION
Fix zh-HK translation

分鍾 -> 分鐘

详情可见 #173 