### PR TITLE
fix: 文章末尾切换上一篇/下一篇的图片修饰丢失

### DIFF
--- a/source/css/_common/components/post/nav.styl
+++ b/source/css/_common/components/post/nav.styl
@@ -20,6 +20,7 @@
       padding: 1.25rem 2.5rem;
       background-size: cover;
       position: relative;
+      transform: scale(1);
 
       &::before {
         content: "";


### PR DESCRIPTION
fix #282 