### PR TITLE
Fix preload image link behavior for covers array and single cover

### DIFF
--- a/layout/_partials/layout.pug
+++ b/layout/_partials/layout.pug
@@ -18,9 +18,11 @@ html(lang=page.language?page.language:config.language, style=theme.grayMode ? 'f
         if enablePreload && enableCover
             if enableFixedCover
                 link(rel="preload" href=theme.homeConfig.fixedCover as="image" fetchpriority="high")
-            else
+            else if Array.isArray(covers)
                 each image in covers
-                    link(rel="preload" href=image as="image" fetchpriority="high")
+                    link(rel="preload" href!=image as="image" fetchpriority="high")
+            else
+                link(rel="preload" href!=covers as="image" fetchpriority="high")
 
         != partial('_partials/head/head_com.pug')
         != shokax_inject('head')
@@ -141,6 +143,5 @@ html(lang=page.language?page.language:config.language, style=theme.grayMode ? 'f
         != _js('siteInit.js')
 
         != shokax_inject('bodyEnd')
-
 
 


### PR DESCRIPTION
## When preloading cover images in the header, there are two issues with the current implementation:

1. For multiple covers (array), the `href` attribute contains the entire array stringified rather than individual image URLs:
```html
<!-- Current incorrect output -->
<link rel="preload" href="[&quot;https://example.com/1.jpg&quot;,&quot;https://example.com/2.jpg&quot;]" as="image">
```

2. For a single cover (string), the string is incorrectly iterated character by character, resulting in multiple preload links for each character:
```html
<!-- Current incorrect output -->
<link rel="preload" href="/" as="image">
<link rel="preload" href="c" as="image">
<link rel="preload" href="o" as="image">
<link rel="preload" href="v" as="image">
```

## Expected Behavior
- For multiple covers: Each image URL should have its own preload link
- For single cover: Should only generate one preload link for the entire URL

## Proposed Solution
Update the template logic to handle both array and string cases:

```pug
if enablePreload && enableCover
    if enableFixedCover
        link(rel="preload" href=theme.homeConfig.fixedCover as="image" fetchpriority="high")
    else if Array.isArray(covers)
        each image in covers
            link(rel="preload" href!=image as="image" fetchpriority="high")
    else
        link(rel="preload" href!=covers as="image" fetchpriority="high")
```