### PR TITLE
fix: 修改 footer 显示效果

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -109,6 +109,7 @@ symbol:
   comma: ", "
   period: ". "
   colon: ": "
+  space: " "
   year: "Y"
   month: "M"
 

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -67,6 +67,7 @@ footer:
   powered: "Powered by %s"
   total_views: Total Views
   total_visitors: Total Visitors
+  loading: "Loading..."
 
 counter:
   index:

--- a/languages/ja.yml
+++ b/languages/ja.yml
@@ -109,6 +109,7 @@ symbol:
   comma: "、"
   period: "。"
   colon: "："
+  space: " "
   year: 年
   month: 月
 

--- a/languages/ja.yml
+++ b/languages/ja.yml
@@ -67,6 +67,7 @@ footer:
   powered: "Powered by %s"
   total_views: 閲覧合計数
   total_visitors: 合計閲覧者数
+  loading: "ローディング..."
 
 counter:
   index:

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -67,6 +67,7 @@ footer:
   powered: "基于 %s"
   total_views: 总访问量
   total_visitors: 总访客量
+  loading: "加载中..."
 
 counter:
   index:

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -109,6 +109,7 @@ symbol:
   comma: "，"
   period: "。"
   colon: "："
+  space: " "
   year: 年
   month: 月
 

--- a/languages/zh-HK.yml
+++ b/languages/zh-HK.yml
@@ -67,6 +67,7 @@ footer:
   powered: "基於 %s"
   total_views: 總瀏覽次數
   total_visitors: 訪客總數
+  loading: "載入中..."
 
 counter:
   index:

--- a/languages/zh-HK.yml
+++ b/languages/zh-HK.yml
@@ -109,6 +109,7 @@ symbol:
   comma: "，"
   period: "。"
   colon: "："
+  space: " "
   year: 年
   month: 月
 

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -67,6 +67,7 @@ footer:
   powered: "基於 %s"
   total_views: 總瀏覽次數
   total_visitors: 訪客總數
+  loading: "載入中..."
 
 counter:
   index:

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -109,6 +109,7 @@ symbol:
   comma: "，"
   period: "。"
   colon: "："
+  space: " "
   year: 年
   month: 月
 

--- a/layout/_partials/post/footer.pug
+++ b/layout/_partials/post/footer.pug
@@ -1,13 +1,14 @@
 div(class="meta")
+    if theme.twikoo.enable || theme.waline.pageview
+        span(class="item")
+            span(class="icon")
+                i(class="ic i-eye")
+            span(class="text")
+                !=__('footer.total_views') + __('symbol.colon')
+            - var prefixedPath = post.path.startsWith('/') ? post.path : '/' + post.path
+            span(id="twikoo_visitors" class="waline-pageview-count" data-path=prefixedPath)
+                !=__('footer.loading')
     if date(post.date) !== date(post.updated) || time(post.date) !== time(post.updated)
-        if theme.twikoo.enable || theme.waline.pageview
-            span(class="item")
-                span(class="icon")
-                    i(class="ic i-eye")
-                span(class="text")
-                    !=__('footer.total_views') + __('symbol.colon')
-                - var prefixedPath = post.path.startsWith('/') ? post.path : '/' + post.path
-                span(id="twikoo_visitors" class="waline-pageview-count" data-path=prefixedPath) 正在加载...
         span(class="item")
             span(class="icon")
                 i(class="ic i-calendar-check")

--- a/layout/_partials/post/footer.pug
+++ b/layout/_partials/post/footer.pug
@@ -1,16 +1,18 @@
 div(class="meta")
     if date(post.date) !== date(post.updated) || time(post.date) !== time(post.updated)
         if theme.twikoo.enable || theme.waline.pageview
-            span(class="icon")
-                i(class="ic i-eye")
-            span 此文章已被阅读次数:
-            - var prefixedPath = post.path.startsWith('/') ? post.path : '/' + post.path
-            span(id="twikoo_visitors" class="waline-pageview-count" data-path=prefixedPath) 正在加载...
+            span(class="item")
+                span(class="icon")
+                    i(class="ic i-eye")
+                span(class="text")
+                    !=__('footer.total_views') + __('symbol.colon')
+                - var prefixedPath = post.path.startsWith('/') ? post.path : '/' + post.path
+                span(id="twikoo_visitors" class="waline-pageview-count" data-path=prefixedPath) 正在加载...
         span(class="item")
             span(class="icon")
                 i(class="ic i-calendar-check")
             span(class="text")
-                != __('post.edited')
+                != __('post.edited') + __('symbol.space')
             time(title=__('post.modified') + __('symbol.colon') + full_date(post.updated) itemprop="dateModified" datetime=moment(post.updated).format())
                 != date(post.updated)
 

--- a/layout/page.pug
+++ b/layout/page.pug
@@ -46,6 +46,9 @@ block content
                 != _p('counter.tag_cloud', site.tags.length)
             div(class="tag cloud")
                 != tagcloud({min_font: theme.tagcloud.min,max_font: theme.tagcloud.max,amount: theme.tagcloud.amount,color: true,start_color: theme.tagcloud.start,end_color: theme.tagcloud.end})
+    else if page.type == '404'
+        div(class="collapse wrap")
+            img(loading="lazy" data-src=`${url_for(theme.statics + theme.assets + '/404.png') }` alt=`${ author } ${ __('title.not_found') }`)
     else
         div(class="page wrap")
             != partial('_partials/post/post.pug', {post: page})

--- a/layout/page.pug
+++ b/layout/page.pug
@@ -46,9 +46,6 @@ block content
                 != _p('counter.tag_cloud', site.tags.length)
             div(class="tag cloud")
                 != tagcloud({min_font: theme.tagcloud.min,max_font: theme.tagcloud.max,amount: theme.tagcloud.amount,color: true,start_color: theme.tagcloud.start,end_color: theme.tagcloud.end})
-    else if page.type == '404'
-        div(class="collapse wrap")
-            img(loading="lazy" data-src=`${url_for(theme.statics + theme.assets + '/404.png') }` alt=`${ author } ${ __('title.not_found') }`)
     else
         div(class="page wrap")
             != partial('_partials/post/post.pug', {post: page})


### PR DESCRIPTION
原始效果：
![image](https://github.com/user-attachments/assets/354477c2-36e1-476e-a461-b6505fcfa3d8)

修改后的效果：
![image](https://github.com/user-attachments/assets/bd3f4aa5-e1bd-49b4-b0f1-9c72513c1610)

更新日期和阅读量这两个显示内容应该是独立的，原来的版本阅读量放在更新日期判断条件下面了，这里也一并把它拿出来了。
然后把一些硬编码的文本用 i18n 里面的替换了。