### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "theme-shokax-anime": "^0.0.7",
         "theme-shokax-pjax": "^0.0.3",
         "twikoo": "^1.6.41",
-        "unlazy": "^0.12.1"
+        "unlazy": "^0.12.1",
+        "dompurify": "^3.2.3"
     },
     "engines": {
         "node": ">=18.0.0"

--- a/source/js/_app/page/fancybox.ts
+++ b/source/js/_app/page/fancybox.ts
@@ -1,6 +1,7 @@
 import { $dom } from '../library/dom'
 import { vendorCss, vendorJs } from '../library/loadFile'
 import { insertAfter } from '../library/proto'
+import DOMPurify from 'dompurify';
 
 // TODO 使用PhotoSwipe替换Fancybox
 export const postFancybox = (p:string) => {
@@ -20,7 +21,7 @@ export const postFancybox = (p:string) => {
 
     $dom.each(p + ' .md img:not(.emoji):not(.vemoji)', (element) => {
       const $image = $(element)
-      const imageLink = $image.attr('data-src') || $image.attr('src') // 替换
+      const imageLink = DOMPurify.sanitize($image.attr('data-src') || $image.attr('src')) // 替换
       const $imageWrapLink = $image.wrap('<a class="fancybox" href="' + imageLink + '" itemscope itemtype="https://schema.org/ImageObject" itemprop="url"></a>').parent('a')
       let info; let captionClass = 'image-info'
       if (!$image.is('a img')) {


### PR DESCRIPTION
Potential fix for [https://github.com/theme-shoka-x/hexo-theme-shokaX/security/code-scanning/1](https://github.com/theme-shoka-x/hexo-theme-shokaX/security/code-scanning/1)

To fix the problem, we need to ensure that the `data-src` attribute value is properly sanitized or escaped before being used to construct the HTML string. The best way to fix this without changing existing functionality is to use a library like `DOMPurify` to sanitize the `data-src` value. This will ensure that any potentially malicious content is neutralized before it is used in the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
